### PR TITLE
284 약속 생성 실패시 롤백 기능 추가

### DIFF
--- a/src/hooks/useAppointmentFormHooks.tsx
+++ b/src/hooks/useAppointmentFormHooks.tsx
@@ -107,9 +107,7 @@ const useAppointmentFormHooks = () => {
     }
     try {
       setIsProcessing(true);
-      const data = await addAppointment();
-      await addAppointmentParticipants(data?.[0].id);
-      //await updateAppointmentProposer(userData.id, data?.[0].id);
+       await addAppointment();
       navigation.goBack();
       addToast({
         success: true,

--- a/src/hooks/useAppointmentFormHooks.tsx
+++ b/src/hooks/useAppointmentFormHooks.tsx
@@ -2,6 +2,8 @@ import {useCallback, useState} from 'react';
 import {useAppointmentForm, useUserStore, useToastStore} from '@/store/store';
 import {useFocusEffect, useNavigation} from '@react-navigation/native';
 import {
+  deleteAppointmentParticipantsSpb,
+  deleteAppointmentSpb,
   setAppointmentParticipantsSpb,
   setAppointmentProposerSpb,
   setAppointmentSpb,
@@ -155,7 +157,7 @@ const useAppointmentFormHooks = () => {
   };
 
   // 약속 참석자 row 추가
-  const addAppointmentParticipants = async (id: string) => {
+  const addAppointmentParticipants = async (id: number) => {
     if (!appointmentForm.appointment_participants_list) {
       return;
     }
@@ -171,6 +173,7 @@ const useAppointmentFormHooks = () => {
     );
 
     if (error) {
+      await deleteAppointment(id);
       throw Error;
     }
     return data;
@@ -183,8 +186,20 @@ const useAppointmentFormHooks = () => {
   ) => {
     const {error} = await setAppointmentProposerSpb(userId, appointmentId);
     if (error) {
+      await deleteAppointmentParticipants(appointmentId);
+      await deleteAppointment(appointmentId);
       throw Error;
     }
+  };
+
+  // 약속 생성 api 실패로 인한 약속 삭제
+  const deleteAppointment = async (appointmentId: number) => {
+    await deleteAppointmentSpb(appointmentId);
+  };
+
+  // 약속 생성 api 실패로 인한 약속 참여자 삭제
+  const deleteAppointmentParticipants = async (appointmentId: number) => {
+    await deleteAppointmentParticipantsSpb(appointmentId);
   };
 
   return {

--- a/src/hooks/useAppointmentFormHooks.tsx
+++ b/src/hooks/useAppointmentFormHooks.tsx
@@ -109,7 +109,7 @@ const useAppointmentFormHooks = () => {
       setIsProcessing(true);
       const data = await addAppointment();
       await addAppointmentParticipants(data?.[0].id);
-      await updateAppointmentProposer(userData.id, data?.[0].id);
+      //await updateAppointmentProposer(userData.id, data?.[0].id);
       navigation.goBack();
       addToast({
         success: true,
@@ -153,6 +153,7 @@ const useAppointmentFormHooks = () => {
     if (error) {
       throw error;
     }
+    await addAppointmentParticipants(data?.[0].id);
     return data;
   };
 
@@ -172,6 +173,8 @@ const useAppointmentFormHooks = () => {
       participants_uuid,
     );
 
+    await updateAppointmentProposer(userData.id, id);
+
     if (error) {
       await deleteAppointment(id);
       throw Error;
@@ -185,6 +188,7 @@ const useAppointmentFormHooks = () => {
     appointmentId: number,
   ) => {
     const {error} = await setAppointmentProposerSpb(userId, appointmentId);
+    
     if (error) {
       await deleteAppointmentParticipants(appointmentId);
       await deleteAppointment(appointmentId);

--- a/src/supabase/appointmentSpb.tsx
+++ b/src/supabase/appointmentSpb.tsx
@@ -43,7 +43,7 @@ export const setAppointmentSpb = ({
 // 약속 참여자 업데이트
 export const setAppointmentParticipantsSpb = (
   appointment_id: number,
-  participants_uuid: string,
+  participants_uuid: string[],
 ) => {
   return supabase.rpc('insert_appointment_participants', {
     appointment_id,
@@ -291,19 +291,14 @@ export const getAppointmentSingleSpb = async (
   id: string,
   appointment_id: number,
 ) => {
-  try {
-    return await supabase.rpc('select_appointment_single_detail', {
-      appointment_id_int: appointment_id,
-      user_uuid: id,
-    });
-  } catch (e) {
-    throw e;
-  }
+  return await supabase.rpc('select_appointment_single_detail', {
+    appointment_id_int: appointment_id,
+    user_uuid: id,
+  });
 };
 
 // 약속 상태 확인
 export const getAppointmentStatusSpb = async (appointment_id: number) => {
-  try {
     const {data, error} = await supabase
       .from('appointment')
       .select('appointment_status')
@@ -313,7 +308,19 @@ export const getAppointmentStatusSpb = async (appointment_id: number) => {
       throw error;
     }
     return data;
-  } catch (e) {
-    throw e;
-  }
 };
+
+
+export const deleteAppointmentSpb  =  (appointmentId: number) => {
+  return supabase
+    .from('appointment')
+    .delete()
+    .eq('appointment_id', appointmentId)
+}
+
+export const deleteAppointmentParticipantsSpb  = (appointmentId: number) => {
+  return supabase 
+    .from('appointment_participants')
+    .delete()
+    .eq('appointment_id', appointmentId)
+}


### PR DESCRIPTION
약속을 생성할 때 총 3개의 api 요청이 들어갑니다.
1. 약속 row 생성
2. 약속 참가자 row 생성
3. 생성한 약속 참가자 중 방장 row를 찾아 상태 업데이트

2번까지는 정상적으로 실행되고 3번만 비정상으로 종료되는 경우 이미 생성한 row들이 여전히 남아있습니다.
리스트에서 비정상적으로 보여지는 증상을 방지하기 위해 비정상적으로 종료된 api 요청에 대해서는 row를 삭제하는 기능을 추가하였습니다.