### PR TITLE
[feat] 약속 거절 시 대기 리스트에서 삭제 기능 구현

### DIFF
--- a/src/components/home/AppointmentItem.tsx
+++ b/src/components/home/AppointmentItem.tsx
@@ -108,7 +108,7 @@ const AppointmentItem = ({
                   styles.profileImgUrl,
                   idx !== 0 && styles.marginLeftMinus,
                 ]}
-                key={el.user_id}
+                key={el.user_id + item.ap_id}
               />
             ) : (
               <View

--- a/src/hooks/useHomeAppointments.tsx
+++ b/src/hooks/useHomeAppointments.tsx
@@ -1,7 +1,7 @@
 import {useCallback, useEffect, useState} from 'react';
 import {Platform} from 'react-native';
 import {useNavigation} from '@react-navigation/native';
-import {useModalStore, useToastStore, useUserStore} from '@/store/store';
+import {useAppointmentsStore, useModalStore, useToastStore, useUserStore} from '@/store/store';
 import {
   getAppointmentsSpb,
   setListDisplaySpb,
@@ -35,8 +35,8 @@ const useHomeAppointments = () => {
   const addToast = useToastStore(state => state.addToast);
   const {openModal, closeModal} = useModalStore();
   const {userData, setUserDataByKey} = useUserStore();
-  const navigation = useNavigation<StackNavigation>();
-  const [appointments, setAppointments] = useState<AppointmentProps[]>([]);
+  const navigation = useNavigation<StackNavigation>();  
+  const {appointments, setAppointments} = useAppointmentsStore()
   const [sort, setSort] = useState<AppointmentTabStatus>(categories[0].value);
   const [selectedId, setSelectedId] = useState(0);
 
@@ -123,6 +123,7 @@ const useHomeAppointments = () => {
       userData.id,
       categories.filter(el => el.value === sortValue)[0].status,
     );
+
     if (error) {
       addToast({
         success: false,
@@ -238,6 +239,11 @@ const useHomeAppointments = () => {
     closeModal();
   };
 
+  // deleteAppointmentByChangeStatus
+  const deleteAppointmentByChangeStatus =  (appointmentId: number) => {
+    setAppointments(prev => prev.filter(el => el.ap_id !== appointmentId));
+  };
+
   return {
     categories,
     appointments,
@@ -249,6 +255,7 @@ const useHomeAppointments = () => {
     createButtonList,
     bottomSheetShow,
     setBottomSheetShow,
+    deleteAppointmentByChangeStatus
   };
 };
 

--- a/src/pages/home/AppointmentDetail.tsx
+++ b/src/pages/home/AppointmentDetail.tsx
@@ -3,7 +3,12 @@ import {View} from 'react-native';
 import {useNavigation} from '@react-navigation/native';
 import dayjs from 'dayjs';
 import {useLocation} from '@/hooks/useLocation';
-import {useAppointmentForm, useAppointmentsStore, useToastStore, useUserStore} from '@/store/store';
+import {
+  useAppointmentForm,
+  useAppointmentsStore,
+  useToastStore,
+  useUserStore,
+} from '@/store/store';
 import {commonStyle} from '@/styles/common';
 import {
   getAppointmentCancellationStatusSpb,
@@ -30,7 +35,7 @@ const AppointmentDetail = () => {
   const [myPiggy, setMyPiggy] = useState<number>(0);
   const {location} = useLocation();
   const navigation = useNavigation();
-  const {deleteAppointment} = useAppointmentsStore()
+  const {deleteAppointment, appointments} = useAppointmentsStore();
 
   useEffect(() => {
     getAppointmentCancellationStatus();
@@ -238,14 +243,16 @@ const AppointmentDetail = () => {
           text: `약속을 ${type ? '수락' : '거절'}했어요.`,
         });
 
-        const res = await getAppointmentStatusSpb(appointmentForm?.id)
-        if(res.appointment_status === 'cancelled' || res.appointment_status === 'confirmed') {
-          deleteAppointment(appointmentForm?.id)
+        const res = await getAppointmentStatusSpb(appointmentForm?.id);
+        if (
+          (res.appointment_status === 'cancelled' ||
+            res.appointment_status === 'confirmed') &&
+          appointments[0].appointment_status
+        ) {
+          deleteAppointment(appointmentForm?.id);
         }
-        
-        
+
         navigation.navigate('Home', {id: appointmentForm?.id});
-        
       }
     } catch {
       addToast({

--- a/src/pages/home/Home.tsx
+++ b/src/pages/home/Home.tsx
@@ -22,6 +22,7 @@ const Home = () => {
     bottomSheetShow,
     setBottomSheetShow,
     changeSort,
+    deleteAppointmentByChangeStatus
   } = useHomeAppointments();
   const flatListRef = useRef<FlatList>(null); // 카테고리 변경 시 스크롤 최상단으로 이동
 
@@ -56,7 +57,6 @@ const Home = () => {
             <AppointmentItem
               item={item}
               onPressMore={onPressMore}
-              onPressFix={onPressFix}
             />
           )}
           ListEmptyComponent={

--- a/src/store/store.ts
+++ b/src/store/store.ts
@@ -8,7 +8,7 @@ import {
   UserStore,
 } from '@/types/common';
 import {ModalProps} from 'react-native';
-import { AppointmentProps } from '@/types/appointment';
+import {AppointmentProps} from '@/types/appointment';
 
 export const useUserStore = create<UserStore>(set => ({
   userData: {
@@ -229,6 +229,10 @@ export const useNotificationStore = create<NotificationStore>(set => ({
 
 export const useAppointmentsStore = create<AppointmentStore>(set => ({
   appointments: [],
-  setAppointments: (appointments:AppointmentProps[]) => set(() => ({appointments})),
-  deleteAppointment: (appointmentId: number) => set((state) => ({appointments: state.appointments.filter(el => el.ap_id !== appointmentId)})),
-}))
+  setAppointments: (appointments: AppointmentProps[]) =>
+    set(() => ({appointments})),
+  deleteAppointment: (appointmentId: number) =>
+    set(state => ({
+      appointments: state.appointments.filter(el => el.ap_id !== appointmentId),
+    })),
+}));

--- a/src/store/store.ts
+++ b/src/store/store.ts
@@ -1,12 +1,14 @@
 import {create} from 'zustand';
 import {
   AppointmentFormStore,
+  AppointmentStore,
   ModalStore,
   NotificationStore,
   ToastStore,
   UserStore,
 } from '@/types/common';
 import {ModalProps} from 'react-native';
+import { AppointmentProps } from '@/types/appointment';
 
 export const useUserStore = create<UserStore>(set => ({
   userData: {
@@ -224,3 +226,9 @@ export const useNotificationStore = create<NotificationStore>(set => ({
   handleAllConfirmAlarm: async () => {},
   setHandleAllConfirmAlarm: fn => set(() => ({handleAllConfirmAlarm: fn})),
 }));
+
+export const useAppointmentsStore = create<AppointmentStore>(set => ({
+  appointments: [],
+  setAppointments: (appointments:AppointmentProps[]) => set(() => ({appointments})),
+  deleteAppointment: (appointmentId: number) => set((state) => ({appointments: state.appointments.filter(el => el.ap_id !== appointmentId)})),
+}))

--- a/src/supabase/appointmentSpb.tsx
+++ b/src/supabase/appointmentSpb.tsx
@@ -303,17 +303,16 @@ export const getAppointmentSingleSpb = async (
 
 // 약속 상태 확인
 export const getAppointmentStatusSpb = async (appointment_id: number) => {
-  try {
+  
     const {data, error} = await supabase
       .from('appointment')
       .select('appointment_status')
-      .eq('appointment_id', appointment_id)
+      .eq('id', appointment_id)
       .single();
     if (error) {
+      console.log(error)
       throw error;
     }
     return data;
-  } catch (e) {
-    throw e;
-  }
 };
+

--- a/src/types/common.ts
+++ b/src/types/common.ts
@@ -1,6 +1,6 @@
 import {GestureResponderEvent, KeyboardTypeOptions} from 'react-native';
 import {SvgProps} from 'react-native-svg';
-import {AppointmentInsertProps} from './appointment';
+import {AppointmentInsertProps, AppointmentProps} from './appointment';
 import {FriendProp, FriendRelationshipRow} from './friend';
 
 export interface CheckBoxProps {
@@ -265,7 +265,12 @@ export interface AppointmentFormStore {
   resetAppointmentForm: () => void;
 }
 
-interface NotificationStore {
+export interface NotificationStore {
   setHandleAllConfirmAlarm: (fn: () => Promise<void>) => void;
   handleAllConfirmAlarm: () => Promise<void>;
+}
+
+export interface AppointmentStore {
+  appointments: AppointmentProps[];
+  setAppointments: (appointments: AppointmentProps[]) => void;
 }


### PR DESCRIPTION
약속을 거절하거나 마지막으로 승낙하는 경우 각각 대기 리스트에서 사라지고 확장/완료 리스트로 이동해야 합니다.
여전히 대기리스트에 나타나는 증상을 발견하여 수정하였습니다.
이 과정에서 props drilling이 많이 발생하여 약속 리스트를 전역 상태관리로 변경하였습니다. 