### PR TITLE
codepush 환경 구성

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -1,4 +1,5 @@
 import React, {useEffect} from 'react';
+import CodePush from 'react-native-code-push';
 import {GestureHandlerRootView} from 'react-native-gesture-handler';
 import Router from '@/router/index';
 import {NavigationContainer} from '@react-navigation/native';
@@ -35,4 +36,15 @@ const App = () => {
   );
 };
 
-export default App;
+const codePushOptions = {
+  checkFrequency: CodePush.CheckFrequency.ON_APP_START,
+  updateDialog: {
+    title: '...',
+    optionalUpdateMessage: '...',
+    optionalInstallButtonLabel: '업데이트',
+    optionalIgnoreButtonLabel: '아니요.',
+  },
+  installMode: CodePush.InstallMode.IMMEDIATE,
+};
+
+export default CodePush(codePushOptions)(App);

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -82,6 +82,7 @@ android {
         targetSdkVersion rootProject.ext.targetSdkVersion
         versionCode 1
         versionName "1.1"
+        resValue 'string', "CODE_PUSH_APK_BUILD_TIME", String.format("\"%d\"", System.currentTimeMillis())
     }
     signingConfigs {
         debug {
@@ -102,6 +103,7 @@ android {
     buildTypes {
         debug {
             signingConfig signingConfigs.debug
+            resValue "string", "CodePushDeploymentKey", CODEPUSH_DEPLOYMENT_KEY_DEBUG
         }
         release {
             // Caution! In production, you need to generate your own keystore file.
@@ -109,6 +111,12 @@ android {
             signingConfig signingConfigs.release
             minifyEnabled enableProguardInReleaseBuilds
             proguardFiles getDefaultProguardFile("proguard-android.txt"), "proguard-rules.pro"
+            resValue "string", "CodePushDeploymentKey", CODEPUSH_DEPLOYMENT_KEY_PRODUCTION
+        }
+        releaseStaging {
+            initWith release
+            resValue "string", "CodePushDeploymentKey", CODEPUSH_DEPLOYMENT_KEY_STAGING
+            matchingFallbacks = ['release']
         }
     }
 }
@@ -126,3 +134,4 @@ dependencies {
 }
 
 apply from: file("../../node_modules/@react-native-community/cli-platform-android/native_modules.gradle"); applyNativeModulesAppBuildGradle(project)
+apply from: file("../../node_modules/react-native-code-push/android/codepush.gradle")

--- a/android/app/src/main/java/com/cheeruptwogether/MainApplication.kt
+++ b/android/app/src/main/java/com/cheeruptwogether/MainApplication.kt
@@ -10,6 +10,7 @@ import com.facebook.react.defaults.DefaultNewArchitectureEntryPoint.load
 import com.facebook.react.defaults.DefaultReactHost.getDefaultReactHost
 import com.facebook.react.defaults.DefaultReactNativeHost
 import com.facebook.soloader.SoLoader
+import com.microsoft.codepush.react.CodePush
 
 class MainApplication : Application(), ReactApplication {
 
@@ -27,6 +28,10 @@ class MainApplication : Application(), ReactApplication {
 
         override val isNewArchEnabled: Boolean = BuildConfig.IS_NEW_ARCHITECTURE_ENABLED
         override val isHermesEnabled: Boolean = BuildConfig.IS_HERMES_ENABLED
+          // 여기에 CodePush 추가
+        override fun getJSBundleFile(): String? {
+          return CodePush.getJSBundleFile()
+        }
       }
 
   override val reactHost: ReactHost

--- a/android/settings.gradle
+++ b/android/settings.gradle
@@ -2,3 +2,7 @@ rootProject.name = 'piggy'
 apply from: file("../node_modules/@react-native-community/cli-platform-android/native_modules.gradle"); applyNativeModulesSettingsGradle(settings)
 include ':app'
 includeBuild('../node_modules/@react-native/gradle-plugin')
+
+// CodePush 설정 수정
+include ':react-native-code-push'
+project(':react-native-code-push').projectDir = file('../node_modules/react-native-code-push/android/app')

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "react-native": "0.74.5",
     "react-native-bootsplash": "^6.1.3",
     "react-native-calendars": "^1.1306.0",
+    "react-native-code-push": "^9.0.0",
     "react-native-device-info": "^11.1.0",
     "react-native-dotenv": "^3.4.11",
     "react-native-dropdown-picker": "^5.4.6",


### PR DESCRIPTION
grade.properties 에선
앱 릴리즈 키 정보 및 코드푸쉬 키 정보를 전역변수로 관리하는게 일반적이기때문에
git 저장소에 올리면 안됨 -> 하지만 이미 올라가있는상태기때문에 논의필요