### PR TITLE
[fix] #310 완료탭 - 인증한 약속 라벨 나올 수 있게 수정

### DIFF
--- a/src/components/home/AppointmentItem.tsx
+++ b/src/components/home/AppointmentItem.tsx
@@ -4,8 +4,7 @@ import {TouchableOpacity} from 'react-native-gesture-handler';
 import {useNavigation} from '@react-navigation/native';
 import {StackNavigation} from '@/types/Router';
 import {commonStyle} from '@/styles/common';
-import {AppointmentProps} from '@/types/appointment';
-import {FriendProp} from '@/types/friend';
+import {AppointmentProps, Participant} from '@/types/appointment';
 import useAppointmentTimer from '@/hooks/useAppointmentTimer';
 import {useAppointmentForm, useUserStore} from '@/store/store';
 import SkeletonAppointmentItem from '../skeleton/SkeletonAppointmentItem';
@@ -49,6 +48,11 @@ const AppointmentItem = ({
     ? commonStyle.REGULAR_AA_16
     : commonStyle.REGULAR_33_16;
 
+  // 완료 탭에서 사용할 나의 인증 상태 가져오기(인증 성공 | 인증 실패)
+  const myCertificationStatus = item.appointment_participants_list?.find(
+    (participant: Participant) => participant.user_id === userData.id,
+  )?.certification_status;
+
   const onPress = () => {
     const calendar = dayjs(item?.appointment_date);
     setAppointmentForm({
@@ -57,9 +61,7 @@ const AppointmentItem = ({
       time: calendar.format('HH:mm'),
       id: item.ap_id,
       appointment_participants_list: item.appointment_participants_list.filter(
-        (el: AppointmentProps) => {
-          el.user_id !== userData.id;
-        },
+        el => el.user_id !== userData.id,
       ),
     });
     navigation.navigate('AppointmentDetail');
@@ -115,7 +117,7 @@ const AppointmentItem = ({
           {/* 친구 리스트 */}
           <View style={styles.friendsTagContiner}>
             <View style={{paddingTop: 16, flexDirection: 'row'}}>
-              {item.appointment_participants_list.map((el: FriendProp, idx) =>
+              {item.appointment_participants_list.map((el: Participant, idx) =>
                 el.profile_img_url ? (
                   <Image
                     source={{uri: el.profile_img_url}}
@@ -166,7 +168,7 @@ const AppointmentItem = ({
 
               {/* 이행된 경우 */}
               {item.appointment_status === 'fulfilled' &&
-                (item.certification_status ? (
+                (myCertificationStatus ? (
                   <Text style={styles.pinkLabel}>인증 성공</Text>
                 ) : (
                   <Text style={styles.grayLabel}>인증 실패</Text>

--- a/src/types/appointment.ts
+++ b/src/types/appointment.ts
@@ -19,7 +19,7 @@ export type AppointmentUserCancellationStatus =
 export interface AppointmentProps extends AppointmentInsert {
   appointment_id: number;
   agreement_status: AppointmentTabStatus;
-  appointment_participants_list: [];
+  appointment_participants_list: Participant[];
   user_cancellation_status: AppointmentUserCancellationStatus;
   certification_status: boolean;
   pinned: boolean;
@@ -31,7 +31,7 @@ export type AppointmentInsert =
   Database['public']['Tables']['appointment']['Insert'];
 
 export interface AppointmentInsertProps extends AppointmentInsert {
-  appointment_participants_list?: FriendProp[];
+  appointment_participants_list?: Participant[] | FriendProp[];
   date?: string;
   time?: string;
   totalAmount?: number;


### PR DESCRIPTION
완료 탭에서 전에는 `인증 성공` 라벨이 정상적으로 나왔지만 현재 인증 성공한 약속도 동일하게 인증 실패로 화면에 표시 (구조 변경으로 예상)
- 현재 완료 탭에서는 `인증 실패`, `취소` 두 가지 상태만 화면에 표시되는 중입니다.


내 인증 정보를 받아올 수 있는 `myCertificationStatus` 변수를 생성하고 기존 조건문에 `myCertificationStatus`변수를 사용하는 방법으로 수정
-> 인증 완료한 약속은  `인증 성공` 라벨이 정상적으로 나오는 것을 확인
<img width="352" alt="스크린샷 2024-11-03 오후 2 43 45" src="https://github.com/user-attachments/assets/318cc33c-2d2d-418d-962b-2c8710daf689">
